### PR TITLE
관심웹툰 단일조회 추가 및 삭제로직 변경

### DIFF
--- a/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
@@ -43,10 +43,17 @@ public class MemberController {
         return ResponseEntity.ok(members);
     }
 
+    @GetMapping("/favorite/{WebtoonId}")
+    public ResponseEntity<InterestedWebtoonResponse> getFavoriteWebtoon(
+        @Auth Long memberId,
+        @PathVariable Long WebtoonId) {
+        return ResponseEntity.ok(memberService.getFavoriteWebtoon(memberId, WebtoonId));
+    }
+
     @GetMapping("/favorite")
     public ResponseEntity<List<InterestedWebtoonResponse>> getAllFavoriteWebtoon(
         @Auth Long memberId) {
-        return ResponseEntity.ok(memberService.getFavoriteWebtoon(memberId));
+        return ResponseEntity.ok(memberService.getAllFavoriteWebtoon(memberId));
     }
 
     @DeleteMapping("/favorite/{WebtoonId}")

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
@@ -49,10 +49,10 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getFavoriteWebtoon(memberId));
     }
 
-    @DeleteMapping("/favorite/{InterestedWebtoonId}")
+    @DeleteMapping("/favorite/{WebtoonId}")
     public ResponseEntity<Void> deleteFavoriteWebtoon(@Auth Long memberId,
-        @PathVariable Long InterestedWebtoonId) {
-        memberService.deleteFavoriteWebtoon(memberId, InterestedWebtoonId);
+        @PathVariable Long WebtoonId) {
+        memberService.deleteFavoriteWebtoon(memberId, WebtoonId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pretzel.dreamketcherbe.common.annotation.Auth;
 import pretzel.dreamketcherbe.domain.member.dto.InterestedWebtoonResponse;
+import pretzel.dreamketcherbe.domain.member.dto.InterestedWebtoonSimpleResponse;
 import pretzel.dreamketcherbe.domain.member.dto.NicknameRequest;
 import pretzel.dreamketcherbe.domain.member.dto.SelfInfoResponse;
 import pretzel.dreamketcherbe.domain.member.entity.Member;
@@ -44,7 +45,7 @@ public class MemberController {
     }
 
     @GetMapping("/favorite/{WebtoonId}")
-    public ResponseEntity<InterestedWebtoonResponse> getFavoriteWebtoon(
+    public ResponseEntity<InterestedWebtoonSimpleResponse> getFavoriteWebtoon(
         @Auth Long memberId,
         @PathVariable Long WebtoonId) {
         return ResponseEntity.ok(memberService.getFavoriteWebtoon(memberId, WebtoonId));

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
@@ -44,7 +44,7 @@ public class MemberController {
     }
 
     @GetMapping("/favorite")
-    public ResponseEntity<List<InterestedWebtoonResponse>> getFavoriteWebtoon(
+    public ResponseEntity<List<InterestedWebtoonResponse>> getAllFavoriteWebtoon(
         @Auth Long memberId) {
         return ResponseEntity.ok(memberService.getFavoriteWebtoon(memberId));
     }

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/dto/InterestedWebtoonResponse.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/dto/InterestedWebtoonResponse.java
@@ -1,23 +1,31 @@
 package pretzel.dreamketcherbe.domain.member.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import pretzel.dreamketcherbe.domain.member.entity.InterestedWebtoon;
 
-// FavoriteWebtoonResponse.java
 public record InterestedWebtoonResponse(
     Long interestedWebtoonId,
     Long webtoonId,
     String title,
     String thumbnail,
-    String description
+    String AuthorNickname,
+    LocalDateTime updatedAt,
+    int episodeCount,
+    List<String> genres
 ) {
 
-    public static InterestedWebtoonResponse from(InterestedWebtoon interestedWebtoon) {
+    public static InterestedWebtoonResponse from(InterestedWebtoon interestedWebtoon,
+        String authorNickname, int episodeCount, LocalDateTime updatedAt, List<String> genres) {
         return new InterestedWebtoonResponse(
             interestedWebtoon.getId(),
             interestedWebtoon.getWebtoon().getId(),
             interestedWebtoon.getWebtoon().getTitle(),
             interestedWebtoon.getWebtoon().getThumbnail(),
-            interestedWebtoon.getWebtoon().getDescription()
+            authorNickname,
+            updatedAt,
+            episodeCount,
+            genres
         );
     }
 }

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/dto/InterestedWebtoonSimpleResponse.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/dto/InterestedWebtoonSimpleResponse.java
@@ -1,0 +1,20 @@
+package pretzel.dreamketcherbe.domain.member.dto;
+
+import pretzel.dreamketcherbe.domain.member.entity.InterestedWebtoon;
+
+public record InterestedWebtoonSimpleResponse(
+    Long interestedWebtoonId,
+    Long webtoonId,
+    String title,
+    String thumbnail
+) {
+
+    public static InterestedWebtoonSimpleResponse from(InterestedWebtoon interestedWebtoon) {
+        return new InterestedWebtoonSimpleResponse(
+            interestedWebtoon.getId(),
+            interestedWebtoon.getWebtoon().getId(),
+            interestedWebtoon.getWebtoon().getTitle(),
+            interestedWebtoon.getWebtoon().getThumbnail()
+        );
+    }
+}

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/repository/InterestedWebtoonRepository.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/repository/InterestedWebtoonRepository.java
@@ -13,6 +13,5 @@ public interface InterestedWebtoonRepository extends JpaRepository<InterestedWeb
 
     Optional<InterestedWebtoon> findByMemberAndWebtoon(Member member, Webtoon webtoon);
 
-    Optional<InterestedWebtoon> findByIdAndMemberId(Long id, Long memberId);
-
+    Optional<InterestedWebtoon> findByWebtoonIdAndMemberId(Long webtoonId, Long memberId);
 }

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
@@ -43,7 +43,7 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    public List<InterestedWebtoonResponse> getFavoriteWebtoon(Long memberId) {
+    public List<InterestedWebtoonResponse> getAllFavoriteWebtoon(Long memberId) {
 
         List<InterestedWebtoon> favoriteWebtoons = interestedWebtoonRepository.findAllByMemberId(
             memberId);

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
@@ -1,10 +1,12 @@
 package pretzel.dreamketcherbe.domain.member.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pretzel.dreamketcherbe.domain.member.dto.InterestedWebtoonResponse;
+import pretzel.dreamketcherbe.domain.member.dto.InterestedWebtoonSimpleResponse;
 import pretzel.dreamketcherbe.domain.member.dto.NicknameRequest;
 import pretzel.dreamketcherbe.domain.member.dto.SelfInfoResponse;
 import pretzel.dreamketcherbe.domain.member.entity.InterestedWebtoon;
@@ -13,6 +15,8 @@ import pretzel.dreamketcherbe.domain.member.exception.MemberException;
 import pretzel.dreamketcherbe.domain.member.exception.MemberExceptionType;
 import pretzel.dreamketcherbe.domain.member.repository.InterestedWebtoonRepository;
 import pretzel.dreamketcherbe.domain.member.repository.MemberRepository;
+import pretzel.dreamketcherbe.domain.webtoon.entity.Webtoon;
+import pretzel.dreamketcherbe.domain.webtoon.repository.WebtoonGenreRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,6 +25,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final InterestedWebtoonRepository interestedWebtoonRepository;
+    private final WebtoonGenreRepository webtoonGenreRepository;
 
     public SelfInfoResponse getSelfInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -43,14 +48,14 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    public InterestedWebtoonResponse getFavoriteWebtoon(Long memberId, Long WebtoonId) {
+    public InterestedWebtoonSimpleResponse getFavoriteWebtoon(Long memberId, Long WebtoonId) {
 
         InterestedWebtoon interestedWebtoon = interestedWebtoonRepository.findByWebtoonIdAndMemberId(
                 WebtoonId, memberId)
             .orElseThrow(
                 () -> new MemberException(MemberExceptionType.INTERESTED_WEBTOON_NOT_FOUND));
 
-        return InterestedWebtoonResponse.from(interestedWebtoon);
+        return InterestedWebtoonSimpleResponse.from(interestedWebtoon);
     }
 
     public List<InterestedWebtoonResponse> getAllFavoriteWebtoon(Long memberId) {
@@ -59,7 +64,23 @@ public class MemberService {
             memberId);
 
         return favoriteWebtoons.stream()
-            .map(InterestedWebtoonResponse::from)
+            .map(interestedWebtoon -> {
+                Webtoon webtoon = interestedWebtoon.getWebtoon();
+                Member author = webtoon.getMember();
+
+                List<String> genres = webtoonGenreRepository.findByWebtoon(webtoon)
+                    .stream()
+                    .map(WebtoonGenre -> WebtoonGenre.getGenre().getName())
+                    .collect(Collectors.toList());
+
+                return InterestedWebtoonResponse.from(
+                    interestedWebtoon,
+                    author.getNickname(),
+                    webtoon.getEpisodeCount(),
+                    webtoon.getUpdatedAt(),
+                    genres
+                );
+            })
             .toList();
     }
 

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
@@ -43,6 +43,16 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    public InterestedWebtoonResponse getFavoriteWebtoon(Long memberId, Long WebtoonId) {
+
+        InterestedWebtoon interestedWebtoon = interestedWebtoonRepository.findByWebtoonIdAndMemberId(
+                WebtoonId, memberId)
+            .orElseThrow(
+                () -> new MemberException(MemberExceptionType.INTERESTED_WEBTOON_NOT_FOUND));
+
+        return InterestedWebtoonResponse.from(interestedWebtoon);
+    }
+
     public List<InterestedWebtoonResponse> getAllFavoriteWebtoon(Long memberId) {
 
         List<InterestedWebtoon> favoriteWebtoons = interestedWebtoonRepository.findAllByMemberId(

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
@@ -58,16 +58,16 @@ public class MemberService {
     }
 
     @Transactional
-    public void deleteFavoriteWebtoon(Long memberId, Long interestedWebtoonId) {
+    public void deleteFavoriteWebtoon(Long memberId, Long WebtoonId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
 
-        InterestedWebtoon interestedWebtoon = interestedWebtoonRepository.findByIdAndMemberId(
-                interestedWebtoonId, memberId)
+        InterestedWebtoon interestedWebtoon = interestedWebtoonRepository.findByWebtoonIdAndMemberId(
+                WebtoonId, memberId)
             .orElseThrow(
                 () -> new MemberException(MemberExceptionType.INTERESTED_WEBTOON_NOT_FOUND));
 
-        if (!interestedWebtoon.getMember().equals(member)) {
+        if (!interestedWebtoon.getMember().getId().equals(memberId)) {
             throw new MemberException(MemberExceptionType.MEMBER_NOT_AUTHORIZED);
         }
 

--- a/src/main/java/pretzel/dreamketcherbe/domain/webtoon/repository/WebtoonGenreRepository.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/webtoon/repository/WebtoonGenreRepository.java
@@ -1,15 +1,18 @@
 package pretzel.dreamketcherbe.domain.webtoon.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import pretzel.dreamketcherbe.domain.webtoon.entity.Webtoon;
 import pretzel.dreamketcherbe.domain.webtoon.entity.WebtoonGenre;
 
-import java.util.List;
-
 public interface WebtoonGenreRepository extends JpaRepository<WebtoonGenre, Long> {
+
     List<WebtoonGenre> findByWebtoonId(Long webtoonId);
+
+    List<WebtoonGenre> findByWebtoon(Webtoon webtoon);
 
     @Query("SELECT wg FROM WebtoonGenre wg WHERE wg.genre.id = :genreId AND wg.webtoon.status = 'IN_SERIES'")
     Page<WebtoonGenre> findByGenreIdAndStatus(Long genreId, Pageable pageable);

--- a/src/main/java/pretzel/dreamketcherbe/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/webtoon/service/WebtoonService.java
@@ -82,7 +82,7 @@ public class WebtoonService {
             .collect(Collectors.toList());
     }
 
-    /*
+    /**
      * 웹툰 등록
      */
     public CreateWebtoonResDto createWebtoon(Long memberId, CreateWebtoonReqDto request) {
@@ -105,7 +105,7 @@ public class WebtoonService {
         return CreateWebtoonResDto.of(newWebtoon);
     }
 
-    /*
+    /**
      * 관심 웹툰 추가
      */
     @Transactional
@@ -120,10 +120,7 @@ public class WebtoonService {
             throw new MemberException(MemberExceptionType.ALREADY_FAVORITED);
         }
 
-        InterestedWebtoon interestedWebtoon = InterestedWebtoon.builder()
-            .member(member)
-            .webtoon(webtoon)
-            .build();
+        InterestedWebtoon interestedWebtoon = createInterestedWebtoon(member, webtoon);
 
         interestedWebtoonRepository.save(interestedWebtoon);
     }
@@ -171,5 +168,12 @@ public class WebtoonService {
             .distinct()
             .map(SearchedWebtoonResDto::of)
             .collect(Collectors.toList());
+    }
+
+    private static InterestedWebtoon createInterestedWebtoon(Member member, Webtoon webtoon) {
+        return InterestedWebtoon.builder()
+            .member(member)
+            .webtoon(webtoon)
+            .build();
     }
 }


### PR DESCRIPTION
## 📝 개요

- 관심웹툰 단일조회 추가 및 삭제로직 변경
- 관심웹툰 목록, 단일 응답값 분리

## ✨ 변경 사항

  - ✨ 관심웹툰 삭제 로직을 webtoon id 값으로 변경
  - ✨ 관심웹툰 단일 조회 기능 추가
  - ✨ 관심웹툰 단일, 목록 dto 분리

## 🔗 관련 이슈

- #82 #83 
