### PR TITLE
작가 작품 조회 필드 변경 및 쿼리 수정

### DIFF
--- a/src/main/java/pretzel/dreamketcherbe/domain/member/dto/WorkResDto.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/dto/WorkResDto.java
@@ -2,12 +2,12 @@ package pretzel.dreamketcherbe.domain.member.dto;
 
 public record WorkResDto(
     Long id,
-    int no,
     String title,
     String thumbnail,
+    int episodeCount,
     String updatedAt,
     String startedAt,
-    Long viewCount,
+    Long likeCount,
     Long commentCount,
     Long interestedCount
 ) {

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import static pretzel.dreamketcherbe.domain.episode.entity.QEpisode.episode;
 import static pretzel.dreamketcherbe.domain.member.entity.QInterestedWebtoon.interestedWebtoon;
 import static pretzel.dreamketcherbe.domain.member.entity.QMember.member;
+import static pretzel.dreamketcherbe.domain.webtoon.entity.QLike.like;
 import static pretzel.dreamketcherbe.domain.webtoon.entity.QSerializationPeriod.serializationPeriod;
 import static pretzel.dreamketcherbe.domain.webtoon.entity.QWebtoon.webtoon;
 
@@ -39,25 +40,26 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
     private List<WorkResDto> getEpisodes(Long memberId, String status, PageReqDto pageReqDto) {
         return jpaQueryFactory.select(
                 Projections.constructor(WorkResDto.class,
-                    episode.id,
-                    episode.no,
+                    webtoon.id,
                     webtoon.title,
                     webtoon.thumbnail,
-                    Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", episode.publishedAt),
+                    webtoon.episodeCount,
+                    Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", webtoon.updatedAt),
                     Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", serializationPeriod.startDate),
-                    episode.viewCount,
-                    Expressions.constant(0L),
                     JPAExpressions.select(interestedWebtoon.count())
                         .from(interestedWebtoon)
-                        .where(interestedWebtoon.webtoon.id.eq(webtoon.id))))
-            .from(episode)
-            .join(episode.webtoon, webtoon)
-            .join(episode.member, member)
+                        .where(interestedWebtoon.webtoon.id.eq(webtoon.id)),
+                    Expressions.constant(0L),
+                    JPAExpressions.select(like.count())
+                        .from(like)
+                        .where(like.webtoon.id.eq(webtoon.id))))
+            .from(webtoon)
+            .join(webtoon.member, member)
             .leftJoin(serializationPeriod).on(serializationPeriod.webtoon.id.eq(webtoon.id))
             .where(getWhereConditions(memberId, status))
             .offset(pageReqDto.getFirstIndex())
             .limit(pageReqDto.getSize())
-            .orderBy(episode.createdAt.desc())
+            .orderBy(webtoon.updatedAt.desc())
             .fetch();
     }
 
@@ -82,7 +84,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
     private BooleanBuilder getWhereConditions(Long memberId, String status) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        builder.and(episode.member.id.eq(memberId));
+        builder.and(webtoon.member.id.eq(memberId));
 
         if ("all".equals(status)) {
             return builder;


### PR DESCRIPTION
## 📝 개요

- 작가 작품 조회 필드 변경 및 쿼리 수정

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 에피소드 조회 -> 웹툰 조회로 쿼리 변경
  - ✨ 조회수 -> 좋아요수 필드 변경

## 🔗 관련 이슈



## ℹ️ 참고 사항

