### PR TITLE
update defaultImage after deleteimage

### DIFF
--- a/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/controller/MemberController.java
@@ -1,20 +1,30 @@
 package pretzel.dreamketcherbe.domain.member.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import pretzel.dreamketcherbe.common.annotation.Auth;
 import pretzel.dreamketcherbe.common.dto.PageReqDto;
 import pretzel.dreamketcherbe.common.dto.PageResDto;
 import pretzel.dreamketcherbe.domain.comment.dto.MyCommentsAndRecommentsListResDto;
 import pretzel.dreamketcherbe.domain.comment.service.CommentService;
-import pretzel.dreamketcherbe.domain.member.dto.*;
+import pretzel.dreamketcherbe.domain.member.dto.InterestedWebtoonResponse;
+import pretzel.dreamketcherbe.domain.member.dto.InterestedWebtoonSimpleResponse;
+import pretzel.dreamketcherbe.domain.member.dto.SelfInfoResponse;
+import pretzel.dreamketcherbe.domain.member.dto.UpdateProfileRequest;
+import pretzel.dreamketcherbe.domain.member.dto.WorkResDto;
 import pretzel.dreamketcherbe.domain.member.entity.Member;
 import pretzel.dreamketcherbe.domain.member.service.MemberService;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/member")

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/dto/UpdateProfileRequest.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/dto/UpdateProfileRequest.java
@@ -12,7 +12,10 @@ public record UpdateProfileRequest(
     String shortIntroduction,
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
-    String businessEmail
+    String businessEmail,
+
+    @NotBlank(message = "이미지 삭제 여부는 필수 입력 값입니다.")
+    Boolean isDeleteImage
 ) {
 
 }

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/service/MemberService.java
@@ -91,6 +91,7 @@ public class MemberService {
         }
     }
 
+    // NOTE: s3Service 메서드 와 Transactional 관계 확인
     @Transactional
     public void updateProfileWithImage(Long memberId, MultipartFile image,
         UpdateProfileRequest profileData) {
@@ -103,27 +104,30 @@ public class MemberService {
             String newShortIntroduction = profileData.shortIntroduction();
 
             updateNickname(member, newNickname, memberId);
-
             updateBusinessEmail(member, newBusinessEmail, memberId);
-
             updateShortIntroduction(member, newShortIntroduction);
         }
 
-        Optional.ofNullable(image)
-            .filter(img -> !img.isEmpty())
-            .ifPresent(img -> {
-                String folderName = "profile-images/" + memberId;
-                String currentImageUrl = member.getImageUrl();
-                String newImageUrl;
+        if (profileData != null && profileData.isDeleteImage()) {
+            s3Service.deleteImage(member.getImageUrl());
+            member.updateImageUrl(defaultProfileImageUrl);
+        } else {
+            Optional.ofNullable(image)
+                .filter(img -> !img.isEmpty())
+                .ifPresent(img -> {
+                    String folderName = "profile-images/" + memberId;
+                    String currentImageUrl = member.getImageUrl();
+                    String newImageUrl;
 
-                if (!currentImageUrl.equals(defaultProfileImageUrl) && currentImageUrl != null) {
-                    newImageUrl = s3Service.imageUpdate(currentImageUrl, img, folderName);
-                } else {
-                    newImageUrl = s3Service.imageUpload(img, folderName);
-                }
-                member.updateImageUrl(newImageUrl);
-            });
-
+                    if (!currentImageUrl.equals(defaultProfileImageUrl)
+                        && currentImageUrl != null) {
+                        newImageUrl = s3Service.imageUpdate(currentImageUrl, img, folderName);
+                    } else {
+                        newImageUrl = s3Service.imageUpload(img, folderName);
+                    }
+                    member.updateImageUrl(newImageUrl);
+                });
+        }
         memberRepository.save(member);
     }
 

--- a/src/test/java/pretzel/dreamketcherbe/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/pretzel/dreamketcherbe/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,137 @@
+package pretzel.dreamketcherbe.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import pretzel.dreamketcherbe.S3Utils.S3Service;
+import pretzel.dreamketcherbe.domain.member.dto.UpdateProfileRequest;
+import pretzel.dreamketcherbe.domain.member.entity.Member;
+import pretzel.dreamketcherbe.domain.member.entity.Role;
+import pretzel.dreamketcherbe.domain.member.entity.SocialType;
+import pretzel.dreamketcherbe.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    // 기본 프로필 이미지 URL (실제 @Value로 주입되지만 테스트에서는 ReflectionTestUtils로 주입)
+    private final String defaultProfileImageUrl = "http://example.com/default.png";
+
+    private Member testMember;
+
+    @BeforeEach
+    public void setUp() {
+        testMember = Member.builder()
+            .socialType(SocialType.GOOGLE)
+            .socialId("123")
+            .email("test@example.com")
+            .name("Test User")
+            .nickname("TestNick")
+            .role(Role.MEMBER)
+            .build();
+
+        // 현재 이미지 URL은 기본 이미지와 다른 값으로 설정 (예: 기존 이미지 URL)
+        testMember.updateImageUrl("http://example.com/old.png");
+
+        // memberRepository.findById()가 호출되면 testMember 반환
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(testMember));
+        // memberRepository.save()는 전달된 인스턴스를 그대로 반환
+        when(memberRepository.save(any(Member.class))).thenAnswer(
+            invocation -> invocation.getArgument(0));
+
+        // memberService의 defaultProfileImageUrl 필드에 테스트용 값을 주입
+        ReflectionTestUtils.setField(memberService, "defaultProfileImageUrl",
+            defaultProfileImageUrl);
+    }
+
+    /**
+     * 케이스 1: 프로필 데이터의 isDeleteImage가 true이면, S3Service.deleteImage 호출 후 기본 이미지 URL로 업데이트
+     */
+    @Test
+    public void testUpdateProfileWithImage_deleteImage() {
+        UpdateProfileRequest request = new UpdateProfileRequest(
+            "NewNick", "New short intro", "new@example.com", true
+        );
+
+        memberService.updateProfileWithImage(1L, null, request);
+
+        verify(s3Service, times(1)).deleteImage("http://example.com/old.png");
+        assertEquals(defaultProfileImageUrl, testMember.getImageUrl());
+
+        assertEquals("NewNick", testMember.getNickname());
+        assertEquals("new@example.com", testMember.getBusinessEmail());
+        assertEquals("New short intro", testMember.getShortIntroduction());
+    }
+
+    /**
+     * 케이스 2: isDeleteImage가 false이고 이미지 파일이 제공된 경우.
+     */
+    @Test
+    public void testUpdateProfileWithImage_updateImage() throws Exception {
+        UpdateProfileRequest request = new UpdateProfileRequest(
+            "UpdatedNick", "Updated intro", "updated@example.com", false
+        );
+
+        MultipartFile image = new MockMultipartFile("image", "test.png", "image/png",
+            "dummy image content".getBytes());
+
+        when(s3Service.imageUpdate(eq("http://example.com/old.png"), eq(image), anyString()))
+            .thenReturn("http://example.com/updated.png");
+
+        memberService.updateProfileWithImage(1L, image, request);
+
+        verify(s3Service, times(1)).imageUpdate(eq("http://example.com/old.png"), eq(image),
+            anyString());
+        verify(s3Service, never()).imageUpload(any(MultipartFile.class), anyString());
+
+        assertEquals("http://example.com/updated.png", testMember.getImageUrl());
+        assertEquals("UpdatedNick", testMember.getNickname());
+        assertEquals("updated@example.com", testMember.getBusinessEmail());
+        assertEquals("Updated intro", testMember.getShortIntroduction());
+    }
+
+    /**
+     * 케이스 3: 프로필 데이터 업데이트만 진행(이미지 파일 없이 isDeleteImage가 false인 경우)
+     */
+    @Test
+    public void testUpdateProfileWithImage_noImageNoDelete() {
+        UpdateProfileRequest request = new UpdateProfileRequest(
+            "NickNoImage", "IntroNoImage", "noimage@example.com", false
+        );
+        memberService.updateProfileWithImage(1L, null, request);
+
+        verify(s3Service, never()).deleteImage(anyString());
+        verify(s3Service, never()).imageUpdate(anyString(), any(MultipartFile.class), anyString());
+        verify(s3Service, never()).imageUpload(any(MultipartFile.class), anyString());
+
+        assertEquals("http://example.com/old.png", testMember.getImageUrl());
+        assertEquals("NickNoImage", testMember.getNickname());
+        assertEquals("noimage@example.com", testMember.getBusinessEmail());
+        assertEquals("IntroNoImage", testMember.getShortIntroduction());
+    }
+}


### PR DESCRIPTION
## 📝 개요

- 기본 프로필 이미지로 변경(기존 이미지 삭제) 추가

## ✨ 변경 사항

  - ✨ updateProfileRequest isdeleteImage 추가  
  - ✨ updateProfileWithImage 기존 이미지 삭제 후 기본 프로필이미지로 변경 로직 추가
