### PR TITLE
fix: folder 내 item 리스트 조회 시 item id 필드 추가

### DIFF
--- a/src/main/java/pretzel/dreamketcherbe/domain/member/dto/StorageItemDetailContentDto.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/dto/StorageItemDetailContentDto.java
@@ -1,6 +1,7 @@
 package pretzel.dreamketcherbe.domain.member.dto;
 
 public record StorageItemDetailContentDto(
+    Long itemId,
     Long webtoonId,
     String title,
     String thumbnail,

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/repository/StorageItemRepositoryCustomImpl.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/repository/StorageItemRepositoryCustomImpl.java
@@ -39,6 +39,7 @@ public class StorageItemRepositoryCustomImpl implements StorageItemRepositoryCus
         return jpaQueryFactory.select(
                 Projections.constructor(
                     pretzel.dreamketcherbe.domain.member.dto.StorageItemDetailContentDto.class,
+                    storageItem.id,
                     webtoon.id,
                     webtoon.title,
                     webtoon.thumbnail,
@@ -69,6 +70,7 @@ public class StorageItemRepositoryCustomImpl implements StorageItemRepositoryCus
         return jpaQueryFactory.select(
                 Projections.constructor(
                     pretzel.dreamketcherbe.domain.member.dto.StorageItemDetailContentDto.class,
+                    storageItem.id,
                     webtoon.id,
                     webtoon.title,
                     webtoon.thumbnail,


### PR DESCRIPTION
## 📝 개요

- 폴더 내 아이템 목록 조회 시 item id 필드 추가함

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ 폴더 내 아이템 목록 조회 시 item id 필드 추가함

## 🔗 관련 이슈

- N/A

## 💬 공유사항

-  N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 저장 항목 상세 정보에 itemId(식별자) 표시가 추가되었습니다.  
* **Bug Fixes**
  * 저장 항목 조회 시 itemId 정보가 포함되어 보다 정확한 데이터 확인이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->