### PR TITLE
feat: 폴더 내 중복된 웹툰 예외 처리

### DIFF
--- a/src/main/java/pretzel/dreamketcherbe/domain/member/exception/StorageFolderExceptionType.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/exception/StorageFolderExceptionType.java
@@ -7,6 +7,7 @@ public enum StorageFolderExceptionType implements ExceptionType {
     FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 폴더를 찾을 수 없습니다."),
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 아이템을 찾을 수 없습니다."),
     PRIVATED_FOLDER_FORBIDDEN(HttpStatus.FORBIDDEN, "비공개 폴더에 접근할 수 없습니다."),
+    DUPLICATE_ITEM(HttpStatus.BAD_REQUEST, "해당 아이템은 이미 있습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/repository/StorageItemRepository.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/repository/StorageItemRepository.java
@@ -1,11 +1,11 @@
 package pretzel.dreamketcherbe.domain.member.repository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import pretzel.dreamketcherbe.domain.member.entity.Member;
+import pretzel.dreamketcherbe.domain.member.entity.StorageFolder;
 import pretzel.dreamketcherbe.domain.member.entity.StorageItem;
+import pretzel.dreamketcherbe.domain.webtoon.entity.Webtoon;
 
 public interface StorageItemRepository extends JpaRepository<StorageItem, Long>, StorageItemRepositoryCustom {
 
-    List<StorageItem> findStorageItemByMember(Member member);
+    boolean existsByStorageFolderAndWebtoon(StorageFolder folder, Webtoon webtoon);
 }

--- a/src/main/java/pretzel/dreamketcherbe/domain/member/service/StorageItemService.java
+++ b/src/main/java/pretzel/dreamketcherbe/domain/member/service/StorageItemService.java
@@ -50,6 +50,7 @@ public class StorageItemService {
         Member member = findByMemberId(memberId);
         StorageFolder folder = findByFolderId(folderId);
         Webtoon webtoon = findByWebtoonId(createStorageItemReqDto.webtoonId());
+        checkWebtoonInFolder(folder, webtoon);
         StorageItem item = StorageItem.create(folder, member, webtoon);
         return CreateStorageItemResDto.of(storageItemRepository.save(item));
     }
@@ -79,5 +80,11 @@ public class StorageItemService {
     private Member findByMemberId(Long memberId) {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+    }
+
+    private void checkWebtoonInFolder(StorageFolder folder, Webtoon webtoon) {
+        if (storageItemRepository.existsByStorageFolderAndWebtoon(folder, webtoon)) {
+            throw new StorageFolderException(StorageFolderExceptionType.DUPLICATE_ITEM);
+        }
     }
 }


### PR DESCRIPTION
## 📝 개요

- 폴더 내 같은 웹툰이 들어가는 문제 해결

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ 폴더 내 중복된 웹툰이 있을 시 예외 처리 

## 🔗 관련 이슈

- N/A

## 💬 공유사항

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 동일한 웹툰을 같은 보관함에 중복으로 추가할 수 없도록 중복 여부를 확인하는 기능이 추가되었습니다.
  * 이미 존재하는 아이템을 추가하려고 할 때 안내 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->